### PR TITLE
Provide `LibplanetExplorerSchema<T>` at `/explorer`

### DIFF
--- a/PlanetNode/GraphTypes/PlanetNodeQuery.cs
+++ b/PlanetNode/GraphTypes/PlanetNodeQuery.cs
@@ -12,12 +12,14 @@ public class PlanetNodeQuery : ObjectGraphType
         Name = "PlanetNodeQuery";
         Field<ExplorerQuery<PolymorphicAction<PlanetAction>>>(
             "explorer",
+            deprecationReason: "Use /graphql/explorer endpoint.",
             resolve: context => new { }
         );
 
         // For compatibility with libplanet-explorer-frontend.
         Field<ExplorerQuery<PolymorphicAction<PlanetAction>>>(
             "chainQuery",
+            deprecationReason: "Use /graphql/explorer endpoint.",
             resolve: context => new { }
         );
         Field<ApplicationQuery>(

--- a/PlanetNode/Program.cs
+++ b/PlanetNode/Program.cs
@@ -9,6 +9,7 @@ using Libplanet.Action;
 using Libplanet.Assets;
 using Libplanet.Explorer.Interfaces;
 using Libplanet.Explorer.Queries;
+using Libplanet.Explorer.Schemas;
 using Libplanet.Extensions.Cocona.Commands;
 using Libplanet.Headless;
 using Libplanet.Headless.Hosting;
@@ -18,6 +19,8 @@ using PlanetNode.GraphTypes;
 using Serilog;
 using System.Collections.Immutable;
 using System.Net;
+
+using PlanetExplorerSchema = Libplanet.Explorer.Schemas.LibplanetExplorerSchema<Libplanet.Action.PolymorphicAction<PlanetNode.Action.PlanetAction>>;
 
 var app = CoconaApp.Create();
 
@@ -57,6 +60,7 @@ app.AddCommand(() =>
         {
             builder
                 .AddSchema<PlanetNodeSchema>()
+                .AddSchema<PlanetExplorerSchema>()
                 .AddGraphTypes(typeof(ExplorerQuery<PolymorphicAction<PlanetAction>>).Assembly)
                 .AddGraphTypes(typeof(PlanetNodeQuery).Assembly)
                 .AddUserContextBuilder<ExplorerContextBuilder>()
@@ -67,6 +71,7 @@ app.AddCommand(() =>
         .AddSingleton<PlanetNodeQuery>()
         .AddSingleton<PlanetNodeMutation>()
         .AddSingleton<GraphQLHttpMiddleware<PlanetNodeSchema>>()
+        .AddSingleton<GraphQLHttpMiddleware<PlanetExplorerSchema>>()
         .AddSingleton<IBlockChainContext<PolymorphicAction<PlanetAction>>, ExplorerContext>();
 
     if (
@@ -92,6 +97,7 @@ app.AddCommand(() =>
         endpoints.MapGraphQLPlayground();
     });
     app.UseGraphQL<PlanetNodeSchema>();
+    app.UseGraphQL<PlanetExplorerSchema>("/graphql/explorer");
 
     app.Run();
 });


### PR DESCRIPTION
This pull request close #41.

---------

This pull request makes planet-node provide `LibplanetExplorerSchema<T>` on the `/explorer` endpoint.

I want to suggest all libplanet implementations reuse `LibplanetExplorerSchema<T>` and [planetarium/libplanet-explorer-frontend](https://github.com/planetarium/libplanet-explorer-frontend) should target the schema for generic support.

Because I don't have permission to assign reviewers, I mention here:

 - @tkiapril libplanet-explorer-frontend maintainer. (or mainly working)
 - @longfin the person who made this project.
 
Related issues:

- https://github.com/planetarium/NineChronicles.Headless/discussions/1690