### PR TITLE
Ignore default store path in Git

### DIFF
--- a/PlanetNode/.gitignore
+++ b/PlanetNode/.gitignore
@@ -44,3 +44,6 @@ UpgradeLog.htm
 *.svclog
 mono_crash.*.json
 mono_crash.*.blob
+
+# Files related planet node chain.
+planet-node-chain


### PR DESCRIPTION
While running `planet-node` with the default option (i.e., appsettings.json), the store is located at `PlanetNode/planet-node-chain`.[^1] but it isn't ignored by `.gitignore` because it doesn't add `planet-node-chain` at `.gitignore`.

This pull request adds the path to `.gitignore`

[^1]: https://github.com/planetarium/planet-node/blob/main/PlanetNode/appsettings.json#L37